### PR TITLE
Added codecov to cookiecutter

### DIFF
--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -8,10 +8,13 @@ python:
   - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+install: pip install -U tox-travis codecov
 
 # Command to run tests, e.g. python setup.py test
 script: tox
+
+# Codecov after success
+after_success: codecov
 
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
 # Assuming you have installed the travis-ci CLI tool, after you

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -10,6 +10,9 @@
 .. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.svg
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
+.. image:: https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/branch/master/graph/badge.svg
+        :target: https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+
 .. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug | replace("_", "-") }}/badge/?version=latest
         :target: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -9,3 +9,4 @@ Sphinx==1.8.1
 twine==1.12.1
 pytest==3.8.2
 pytest-runner==4.2
+pytest-cov==2.6.1

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -23,5 +23,5 @@ deps =
 ;     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
-    py.test --basetemp={envtmpdir}
+    py.test --basetemp={envtmpdir} --cov={{cookiecutter.project_slug}}
 


### PR DESCRIPTION
Projects setup using this cookiecutter now have codecov via travis and tox, plus a badge in the README.