### PR TITLE
Configure PyUp to maintain dependency versions

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,4 @@
+# Specify requirement files by hand
+requirements:
+  - requirements_dev.txt
+  - {{cookiecutter.project_slug}}/requirements_dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,12 @@
 
 language: python
 python:
+  - 3.7
   - 3.6
   - 3.5
-  - 3.4
-  - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
 
 # command to run tests, e.g. python setup.py test
 script: tox
-
-# deploy new versions to PyPI
-deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  user: audreyr
-  password:
-    secure: PLEASE_REPLACE_ME
-  on:
-    tags: true
-    repo: audreyr/python_boilerplate
-    python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,6 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      TOX_ENV: "py27"
-
-    - PYTHON: "C:\\Python27-x64"
-      TOX_ENV: "py27"
-
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,51 @@
+# What Python version is installed where:
+# http://www.appveyor.com/docs/installed-software#python
+
 environment:
   matrix:
-  - TOXENV: py35
-  - TOXENV: py36
-  - TOXENV: py37
+    - PYTHON: "C:\\Python27"
+      TOX_ENV: "py27"
 
-build: off
+    - PYTHON: "C:\\Python27-x64"
+      TOX_ENV: "py27"
+
+    - PYTHON: "C:\\Python35"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python35-x64"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: "py36"
+
+    - PYTHON: "C:\\Python36-x64"
+      TOX_ENV: "py36"
+
+    - PYTHON: "C:\\Python37"
+      TOX_ENV: "py37"
+
+    - PYTHON: "C:\\Python37-x64"
+      TOX_ENV: "py37"
+
+init:
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\msys\1.0\bin;%PATH%
+  - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""
+  - "%PYTHON%/python -V"
+  - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""
 
 install:
-- python -m pip install -U pip tox
+  - "%PYTHON%/Scripts/easy_install -U pip"
+  - "%PYTHON%/Scripts/pip install -U tox virtualenv"
+  - "%PYTHON%/Scripts/pip install wheel"
+
+build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-- tox
+  - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
+
+after_test:
+  - "%PYTHON%/python setup.py --command-packages wheel bdist_wheel"
+  - ps: "ls dist"
+
+artifacts:
+  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,4 +10,4 @@ install:
 - python -m pip install -U pip tox
 
 test_script:
-- python -m tox
+- tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,7 @@ environment:
 build: off
 
 install:
-- python -m pip install -U pip
-- python -m pip install -U tox
+- python -m pip install -U pip tox
 
 test_script:
-- tox
+- python -m tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,18 +3,6 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      TOX_ENV: "py27"
-
-    - PYTHON: "C:\\Python27-x64"
-      TOX_ENV: "py27"
-
-    - PYTHON: "C:\\Python34"
-      TOX_ENV: "py34"
-
-    - PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "py34"
-
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 
@@ -26,6 +14,12 @@ environment:
 
     - PYTHON: "C:\\Python36-x64"
       TOX_ENV: "py36"
+
+    - PYTHON: "C:\\Python37"
+      TOX_ENV: "py37"
+
+    - PYTHON: "C:\\Python37-x64"
+      TOX_ENV: "py37"
 
 init:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\msys\1.0\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,45 +1,13 @@
-# What Python version is installed where:
-# http://www.appveyor.com/docs/installed-software#python
-
 environment:
   matrix:
-    - PYTHON: "C:\\Python35"
-      TOX_ENV: "py35"
+  - TOXENV: py35
+  - TOXENV: py36
+  - TOXENV: py37
 
-    - PYTHON: "C:\\Python35-x64"
-      TOX_ENV: "py35"
-
-    - PYTHON: "C:\\Python36"
-      TOX_ENV: "py36"
-
-    - PYTHON: "C:\\Python36-x64"
-      TOX_ENV: "py36"
-
-    - PYTHON: "C:\\Python37"
-      TOX_ENV: "py37"
-
-    - PYTHON: "C:\\Python37-x64"
-      TOX_ENV: "py37"
-
-init:
-  - set PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\msys\1.0\bin;%PATH%
-  - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""
-  - "%PYTHON%/python -V"
-  - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""
+build: off
 
 install:
-  - "%PYTHON%/Scripts/easy_install -U pip"
-  - "%PYTHON%/Scripts/pip install tox"
-  - "%PYTHON%/Scripts/pip install wheel"
-
-build: false  # Not a C# project, build stuff at the test step instead.
+- pip install tox
 
 test_script:
-  - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
-
-after_test:
-  - "%PYTHON%/python setup.py --command-packages wheel bdist_wheel"
-  - ps: "ls dist"
-
-artifacts:
-  - path: dist\*
+- tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ environment:
 build: off
 
 install:
-- pip install tox
+- python -m pip install -U pip
+- python -m pip install -U tox
 
 test_script:
 - tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
-pytest==3.4.2
-tox==2.9.1
-cookiecutter>=1.4.0
-pytest-cookies==0.3.0
-watchdog==0.8.3
-alabaster==0.7.10
-sphinx_rtd_theme
+pytest==5.1.2
+tox==3.14.0
+cookiecutter==1.6.0
+pytest-cookies==0.4.0
+watchdog==0.9.0
+alabaster==0.7.12
+sphinx-rtd-theme==0.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,4 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
-    pip install -U pip
     py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, docs
+envlist = py{35,36,37}, docs
 skipsdist = true
 
 [travis]

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,5 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
+    python -m pip install -U pip
     py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, docs
+envlist = py35, py36, py37, docs
 skipsdist = true
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
-    3.4: py34
-    2.7: py27
 
 [testenv:docs]
 basepython=python
 changedir=docs
-deps=sphinx
 commands=
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
-    python -m pip install -U pip
+    pip install -U pip
     py.test


### PR DESCRIPTION
This PR adds a config file for PyUp, so that pinned package versions are updated automatically via pull requests that PyUp submits. 

There are a couple of other little things that this cleans up, so that the CI tests on the PyUp PRs are meaningful: 

1. Drop tests for python 2 and 3.4
2. Add tests for python 3.7
3. Remove unnecessary deploy code from .travis.yml (this package is not deployed to PyPI)

This PR relates to an issue raised in #7 by @xmnlab about pinning to outdated package versions.

@kysolvik or @lwasser would you mind giving this a review?