### PR TITLE
switch hatch to dependency groups, split deps to data file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ dist/yourpackage-0.1.0.tar.gz
 dist/yourpackage-0.1.0-py2.py3-none-any.whl
 ```
 
+> [!IMPORTANT]  
+> This template makes use of [PEP-735 `dependency-groups`](https://peps.python.org/pep-0735/)
+> which are only supported in versions of hatch [greater than v1.16.0](https://hatch.pypa.io/dev/blog/2025/11/24/hatch-v1160/#dependency-groups).
+> To see which version of hatch you have installed use `hatch --version`,
+> and to update hatch use [`hatch self update`](https://hatch.pypa.io/dev/cli/reference/#hatch-self-update).
+
 To use the hatch build environment run:
 
 `hatch run build:check`

--- a/copier.yml
+++ b/copier.yml
@@ -167,5 +167,10 @@ use_test:
   default: "yes"
   help: "Do you want to test your code? We strongly recommend that you add tests to your package."
 
+deps:
+  when: false
+  type: yaml
+  multiselect: false
+  default: !include data/dependencies.yml
 
 _subdirectory: "template"

--- a/data/dependencies.yml
+++ b/data/dependencies.yml
@@ -1,0 +1,47 @@
+# Deps are specified as dicts of dicts
+#
+# The top-level key is the key that will be used within the pyproject.toml file,
+# use a `_rename` key to override the name (e.g. two optional groups for docs below)
+#
+# Within each group, 
+# the key is the package name, and the value, if present, is the version constraint.
+# Use empty values to indicate no version constraint.
+
+
+build:
+  pip-audit:
+  twine:
+
+dev:
+  hatch: ">=1.16.0"
+  pre-commit:
+
+mkdocs:
+  _rename: docs
+  mkdocs-material: '~=9.5'
+  mkdocstrings[python]: '~=0.24'
+  mkdocs-awesome-pages-plugin: '~=2.9'
+
+sphinx:
+  _rename: docs
+  sphinx: '~=8.0'
+  myst-parser: '>=4.0'
+  pydata-sphinx-theme: '~=0.16'
+  sphinx-autobuild: '>=2024.10.3'
+  sphinx-autoapi: '>=3.6.0'
+  sphinx_design: '>=0.6.1'
+  sphinx-copybutton: '>=0.5.2'
+
+style:
+  pydoclint:
+  ruff:
+
+tests:
+  pytest:
+  pytest-cov:
+  pytest-raises:
+  pytest-randomly:
+  pytest-xdist:
+
+types:
+  mypy:

--- a/data/dependencies.yml
+++ b/data/dependencies.yml
@@ -1,7 +1,7 @@
 # Deps are specified as dicts of dicts
 #
 # The top-level key is the key that will be used within the pyproject.toml file,
-# use a `_rename` key to override the name (e.g. two optional groups for docs below)
+# unless "key" is specified in the render_deps macro
 #
 # Within each group, 
 # the key is the package name, and the value, if present, is the version constraint.
@@ -17,13 +17,11 @@ dev:
   pre-commit:
 
 mkdocs:
-  _rename: docs
   mkdocs-material: '~=9.5'
   mkdocstrings[python]: '~=0.24'
   mkdocs-awesome-pages-plugin: '~=2.9'
 
 sphinx:
-  _rename: docs
   sphinx: '~=8.0'
   myst-parser: '>=4.0'
   pydata-sphinx-theme: '~=0.16'

--- a/includes/dependencies.toml.jinja
+++ b/includes/dependencies.toml.jinja
@@ -1,0 +1,20 @@
+{# Import this macro like `from .. import render_deps with context` to give it access to the deps data #}
+{% macro render_deps(group, inner=False) %}
+{#- for some reason copier insists on loading things as nested lists inconsistently across versions #}
+{%- if not deps[0] is mapping %}
+  {%- set d=deps[0][0] %}
+{%- else -%}
+  {%- set d=deps[0] %}
+{%- endif -%}
+{%- if group and group in d -%}
+{%- if not inner -%}
+{{ group if "_rename" not in d[group] else d[group]["_rename"] }} = [
+{%- endif %}
+{%- for package, constraint in d[group].items() if package != "_rename" %}
+    "{{ package }}{% if constraint %}{{ constraint }}{% endif %}",
+{%- endfor %}
+{%- if not inner %}
+]
+{%- endif -%}
+{%- endif -%}
+{% endmacro %}

--- a/includes/dependencies.toml.jinja
+++ b/includes/dependencies.toml.jinja
@@ -1,5 +1,5 @@
 {# Import this macro like `from .. import render_deps with context` to give it access to the deps data #}
-{% macro render_deps(group, inner=False) %}
+{% macro render_deps(group, inner=False, key=None) %}
 {#- for some reason copier insists on loading things as nested lists inconsistently across versions #}
 {%- if not deps[0] is mapping %}
   {%- set d=deps[0][0] %}
@@ -8,9 +8,9 @@
 {%- endif -%}
 {%- if group and group in d -%}
 {%- if not inner -%}
-{{ group if "_rename" not in d[group] else d[group]["_rename"] }} = [
+{{ group if not key else key }} = [
 {%- endif %}
-{%- for package in d[group]|sort if package != "_rename" %}
+{%- for package in d[group]|sort %}
     "{{ package }}{% if d[group][package] %}{{ d[group][package] }}{% endif %}",
 {%- endfor %}
 {%- if not inner %}

--- a/includes/dependencies.toml.jinja
+++ b/includes/dependencies.toml.jinja
@@ -10,8 +10,8 @@
 {%- if not inner -%}
 {{ group if "_rename" not in d[group] else d[group]["_rename"] }} = [
 {%- endif %}
-{%- for package, constraint in d[group].items() if package != "_rename" %}
-    "{{ package }}{% if constraint %}{{ constraint }}{% endif %}",
+{%- for package in d[group]|sort if package != "_rename" %}
+    "{{ package }}{% if d[group][package] %}{{ d[group][package] }}{% endif %}",
 {%- endfor %}
 {%- if not inner %}
 ]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -86,7 +86,7 @@ dev = [
     {include-group = "types"},
     {%- endif %}
 ]
-{{ render_deps(documentation) }}
+{{ render_deps(documentation, key="docs") }}
 {{ render_deps("build") }}
 {%- if use_test %}{{ "\n" }}{{ render_deps("tests") }}{% endif %}
 {%- if use_lint %}{{ "\n" }}{{ render_deps("style") }}{% endif %}
@@ -227,7 +227,6 @@ exclude = "_version.py"
 # Use UV to create Hatch environments
 [tool.hatch.envs.default]
 installer = "uv"
-builder = true
 
 ################################################################################
 # Hatch Environments
@@ -241,6 +240,7 @@ description = """Test the installation the package."""
 dependency-groups = [
     "build",
 ]
+{{ render_deps("build", key="dependencies") }}
 detached = true
 builder = true
 
@@ -259,7 +259,6 @@ description = """Run the test suite."""
 dependency-groups = [
     "tests",
 ]
-builder = true
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11", "3.12", "3.13"]
@@ -301,7 +300,6 @@ dependency-groups = [
     "style",
 ]
 detached = true
-builder = true
 
 [tool.hatch.envs.style.scripts]
 docstrings = "pydoclint src/ tests/"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -242,6 +242,7 @@ dependency-groups = [
     "build",
 ]
 detached = true
+builder = true
 
 # This table installs created the command hatch run install:check which will build and check your package.
 [tool.hatch.envs.build.scripts]
@@ -258,6 +259,7 @@ description = """Run the test suite."""
 dependency-groups = [
     "tests",
 ]
+builder = true
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11", "3.12", "3.13"]
@@ -275,7 +277,7 @@ description = """Build or serve the documentation."""
 dependency-groups = [
     "docs",
 ]
-
+builder = true
 # This table contains the scripts that you can use to build and serve your docs
 # hatch run docs:build will build your documentation
 # hatch run docs:serve will serve them 'live' on your computer locally
@@ -299,6 +301,7 @@ dependency-groups = [
     "style",
 ]
 detached = true
+builder = true
 
 [tool.hatch.envs.style.scripts]
 docstrings = "pydoclint src/ tests/"
@@ -314,6 +317,7 @@ description = """Check dependencies for security vulnerabilities."""
 dependency-groups = [
     "build",
 ]
+builder = true
 
 [tool.hatch.envs.audit.scripts]
 check = ["pip-audit"]
@@ -324,6 +328,7 @@ check = ["pip-audit"]
 [tool.hatch.envs.types]
 description = """Check the static types of the codebase."""
 dependency-groups = ["types"]
+builder = true
 
 [tool.hatch.envs.types.scripts]
 check = "mypy src/{{ package_name }}"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -1,3 +1,4 @@
+{%- from pathjoin("includes", "dependencies.toml.jinja") import render_deps with context -%}
 ################################################################################
 # Build Configuration
 ################################################################################
@@ -69,67 +70,27 @@ Documentation = "{{ dev_platform_url }}/{{ username }}/{{ project_slug }}/blob/m
 {%- endif %}
 Download = "https://pypi.org/project/{{ project_slug }}/#files"
 
-[project.optional-dependencies]
-# The groups below should be in the [development-groups] table
-# They are here now because hatch hasn't released support for them but plans to
-# in Mid November 2025.
+[dependency-groups]
 dev = [
-    "hatch",
-    "pre-commit",
-    {%- if not use_hatch_envs %}
-    "{{ package_name }}[
-        {%- if documentation!="" %}docs,{% endif -%}
-        {%- if use_test %}tests,{% endif -%}
-        {%- if use_lint %}style,{% endif -%}
-        {%- if use_types %}types,{% endif -%}
-    audit]",
+{{- render_deps("dev", inner=True) }}
+    {%- if documentation in ("sphinx", "mkdocs") %}
+    {include-group = "docs"},
+    {%- endif %}
+    {%- if use_test %}
+    {include-group = "tests"},
+    {%- endif -%}
+    {%- if use_lint %}
+    {include-group = "style"},
+    {%- endif -%}
+    {%- if use_types %}
+    {include-group = "types"},
     {%- endif %}
 ]
-
-docs = [
-{%- if documentation == "sphinx" %}
-    "sphinx~=8.0",
-    "myst-parser>=4.0",
-    "pydata-sphinx-theme~=0.16",
-    "sphinx-autobuild>=2024.10.3",
-    "sphinx-autoapi>=3.6.0",
-    "sphinx_design>=0.6.1",
-    "sphinx-copybutton>=0.5.2",
-{%- elif documentation == "mkdocs" %}
-    "mkdocs-material ~=9.5",
-    "mkdocstrings[python] ~=0.24",
-    "mkdocs-awesome-pages-plugin ~=2.9",
-{% endif %}
-]
-
-build = [
-    "pip-audit",
-    "twine",
-]
-
-{%- if use_test %}
-tests = [
-    "pytest",
-    "pytest-cov",
-    "pytest-raises",
-    "pytest-randomly",
-    "pytest-xdist",
-]
-{%- endif %}
-
-{%- if use_lint %}
-style = [
-    "pydoclint",
-    "ruff",
-]
-{%- endif %}
-
-{%- if use_types %}
-types = [
-    "mypy",
-]
-{%- endif %}
-
+{{ render_deps(documentation) }}
+{{ render_deps("build") }}
+{%- if use_test %}{{ "\n" }}{{ render_deps("tests") }}{% endif %}
+{%- if use_lint %}{{ "\n" }}{{ render_deps("style") }}{% endif %}
+{%- if use_types %}{{ "\n" }}{{ render_deps("types") }}{% endif %}
 
 ################################################################################
 # Tool Configuration
@@ -266,6 +227,7 @@ exclude = "_version.py"
 # Use UV to create Hatch environments
 [tool.hatch.envs.default]
 installer = "uv"
+builder = true
 
 ################################################################################
 # Hatch Environments
@@ -276,7 +238,7 @@ installer = "uv"
 # This table installs the tools you need to test and build your package
 [tool.hatch.envs.build]
 description = """Test the installation the package."""
-features = [
+dependency-groups = [
     "build",
 ]
 detached = true
@@ -293,7 +255,7 @@ check = [
 {%- if use_test %}
 [tool.hatch.envs.test]
 description = """Run the test suite."""
-features = [
+dependency-groups = [
     "tests",
 ]
 
@@ -310,7 +272,7 @@ run = "pytest {args:--cov={{ package_name }} --cov-report=term-missing --cov-rep
 [tool.hatch.envs.docs]
 description = """Build or serve the documentation."""
 # Install optional dependency test for docs
-features = [
+dependency-groups = [
     "docs",
 ]
 
@@ -333,7 +295,7 @@ serve = ["sphinx-autobuild docs --watch src/{{ package_name }} {args:-b html doc
 
 [tool.hatch.envs.style]
 description = """Check the code and documentation style."""
-features = [
+dependency-groups = [
     "style",
 ]
 detached = true
@@ -349,7 +311,7 @@ check = ["docstrings", "code"]
 
 [tool.hatch.envs.audit]
 description = """Check dependencies for security vulnerabilities."""
-features = [
+dependency-groups = [
     "build",
 ]
 
@@ -361,7 +323,7 @@ check = ["pip-audit"]
 #--------------- Typing ---------------#
 [tool.hatch.envs.types]
 description = """Check the static types of the codebase."""
-features = ["types"]
+dependency-groups = ["types"]
 
 [tool.hatch.envs.types.scripts]
 check = "mypy src/{{ package_name }}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,16 @@
 """Provide fixtures to the entire test suite."""
 
 import shutil
-from pathlib import Path
-from typing import TYPE_CHECKING, Generator
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, Generator
 
 import pytest
+from funcy import lflatten
 from _pytest.monkeypatch import MonkeyPatch
 from jinja2 import Environment, FileSystemLoader
-from ruamel.yaml import YAML
+from ruamel.yaml import YAML, Loader
+from ruamel.yaml.constructor import Constructor
+from ruamel.yaml.nodes import ScalarNode
 
 if TYPE_CHECKING:
     from _pytest.config.argparsing import Parser
@@ -16,9 +19,25 @@ if TYPE_CHECKING:
 COPIER_CONFIG_PATH = Path(__file__).parents[1] / "copier.yml"
 INCLUDES_PATH = Path(__file__).parents[1] / "includes"
 
+# handle copier's !include tags - 
+# they went and did us the favor of making their entire package private,
+# so to respect their wishes to touch nothing we copy it here
+# with mild modifications for our use case and for ruamel.yaml
+# https://github.com/copier-org/copier/blob/24e842d838cf41b90a024ae4f80834add0ea95c2/copier/_template.py#L86
+def _include(loader: Constructor, node: ScalarNode) -> Any:
+    if not isinstance(node, ScalarNode):
+        raise ValueError(f"Unsupported YAML node: {node!r}")
+    include_file = str(loader.construct_scalar(node))
+    if PurePosixPath(include_file).is_absolute():
+        raise ValueError("YAML include file path must be a relative path")
+    path = next(COPIER_CONFIG_PATH.parent.glob(include_file))
+    return [YAML(typ="safe").load(path.read_bytes())]
+
 
 def _load_copier_config() -> dict:
     yaml = YAML(typ="safe")
+    yaml.constructor.add_constructor("!include", _include)
+
     with COPIER_CONFIG_PATH.open("r") as yfile:
         return yaml.load(yfile)
 

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -242,7 +242,7 @@ def test_non_hatch_deps(
     # validate pyproject.toml file if present
     validator_api.Validator()(pyproject)
 
-    optional_deps = pyproject["project"]["optional-dependencies"]
+    optional_deps = pyproject["dependency-groups"]
     groups = ("dev", "tests", "style", "types", "build")
     assert all(group in optional_deps for group in groups)
 

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -29,6 +29,7 @@ from typing import Callable
 import pytest
 from copier import run_copy
 from git import Repo
+from ruamel.yaml import YAML
 from validate_pyproject import api as validator_api
 
 try:
@@ -254,3 +255,21 @@ def test_non_hatch_deps(
     if documentation != "no":
         assert "docs" in optional_deps
         assert any(dep.startswith(documentation) for dep in optional_deps["docs"])
+
+def test_deps_sorted(generated: Callable[..., Path]):
+    """Dependencies in dep groups are sorted when rendering."""
+    unsorted = {"z": None, "x": None, "y": None}
+    with (TEMPLATE / "data" / "dependencies.yml").open() as f:
+        deps = YAML(typ="safe").load(f)
+
+    deps["tests"] = unsorted
+    project = generated(
+        use_test=True,
+        deps=[deps],
+    )
+    pyproject_file = project / "pyproject.toml"
+    with pyproject_file.open("rb") as pfile:
+        pyproject = tomllib.load(pfile)
+
+    assert "tests" in pyproject["dependency-groups"]
+    assert pyproject["dependency-groups"]["tests"] == ["x", "y", "z"]

--- a/tests/test_template_init.py
+++ b/tests/test_template_init.py
@@ -170,7 +170,7 @@ def test_template_suite(
     project_dir = generated()
 
     # Run the local test suite.
-    run_command("hatch build --clean", project_dir)
+    run_command("hatch run build:check", project_dir)
     run_command(f"hatch run +py={sys.version_info.major}.{sys.version_info.minor} test:run", project_dir)
     run_command("hatch run style:check", project_dir)
 


### PR DESCRIPTION
fix: https://github.com/pyOpenSci/pyos-package-template/issues/143

so this does two things, switched us over to dependency groups and splits our dependencies out into data so that the version constraints aren't all mushed up with the form of the template (which is about structure not data).

however for the life of me i can't tell what's going on - the `pyproject.toml` seems to be correctly generated, here is an example with the `minimal` option:

<details>
<summary>expand/collapse pyproject.toml</summary>

```toml
################################################################################
# Build Configuration
################################################################################

[build-system]
build-backend = "hatchling.build"
requires = ["hatchling"]

################################################################################
# Project Configuration
################################################################################

[project]
name = "aaa"
# You can chose to use dynamic versioning with hatch or static where you add it manually.
version = "0.1.0"

description = "a"
authors = [
    { name = "a", email = "a@a.com" },
]
license = "MIT"
requires-python = ">= 3.10" # Adjust based on the minimum version of Python that you support
readme = {"file" = "README.md", "content-type" = "text/markdown"}
# Please consult https://pypi.org/classifiers/ for a full list.
classifiers = [
    "Development Status :: 2 - Pre-Alpha",
    "Intended Audience :: Science/Research",
    "License :: OSI Approved :: MIT License",
    "Operating System :: OS Independent",
    "Programming Language :: Python :: 3 :: Only",
]
# TODO: add keywords
keywords = []
# TODO: add dependencies
dependencies = []

[project.urls]
Homepage = "https://github.com/aaa/aaa"
"Source Code" = "https://github.com/aaa/aaa"
"Bug Tracker" = "https://github.com/aaa/aaa/issues"
Documentation = "https://github.com/aaa/aaa/blob/main/README.md"
Download = "https://pypi.org/project/aaa/#files"

[dependency-groups]
dev = [
    "hatch",
    "pre-commit",
    {include-group = "docs"},
    {include-group = "tests"},
]
docs = [
    "sphinx~=8.0",
    "myst-parser>=4.0",
    "pydata-sphinx-theme~=0.16",
    "sphinx-autobuild>=2024.10.3",
    "sphinx-autoapi>=3.6.0",
    "sphinx_design>=0.6.1",
    "sphinx-copybutton>=0.5.2",
]
build = [
    "pip-audit",
    "twine",
]
tests = [
    "pytest",
    "pytest-cov",
    "pytest-raises",
    "pytest-randomly",
    "pytest-xdist",
]

################################################################################
# Tool Configuration
################################################################################

# Hatch is building your package's wheel and sdist
# This tells hatch to only include Python packages (i.e., folders with __init__.py) in the build.
# read more about package building, here:
# https://www.pyopensci.org/python-package-guide/package-structure-code/python-package-distribution-files-sdist-wheel.html
[tool.hatch.build]
only-packages = true

# This tells Hatch to build the package from the src/ directory.
# Read more about src layouts here: https://www.pyopensci.org/python-package-guide/package-structure-code/python-package-structure.html
[tool.hatch.build.targets.wheel]
packages = ["src/aaa"]



######## Configure pytest for your test suite ########
[tool.pytest.ini_options]
testpaths = ["tests"] # Tells pytest what directory tests are in
markers = ["raises"] # Tells pytest to not raise a warning if you use @pytest.mark.raises

[tool.coverage.paths]
source = [
    "src/aaa",
    "*/site-packages/aaa",
]

[tool.coverage.run]
# Ensures code coverage is measured for branches (conditional statements with different outcomes) in your code.
branch = true
parallel = true

[tool.coverage.report]
# This configures the output test coverage report
exclude_lines = ["pragma: no cover"]
precision = 2


# Use UV to create Hatch environments
[tool.hatch.envs.default]
installer = "uv"
builder = true

################################################################################
# Hatch Environments
################################################################################

#--------------- Build and check your package ---------------#

# This table installs the tools you need to test and build your package
[tool.hatch.envs.build]
description = """Test the installation the package."""
dependency-groups = [
    "build",
]
detached = true
builder = true

# This table installs created the command hatch run install:check which will build and check your package.
[tool.hatch.envs.build.scripts]
check = [
    "hatch build {args:--clean}",
    "twine check dist/*",
]

#--------------- Run tests ---------------#
[tool.hatch.envs.test]
description = """Run the test suite."""
dependency-groups = [
    "tests",
]

[[tool.hatch.envs.test.matrix]]
python = ["3.10", "3.11", "3.12", "3.13"]

[tool.hatch.envs.test.scripts]
run = "pytest {args:--cov=aaa --cov-report=term-missing --cov-report=xml}"

#--------------- Build and preview your documentation ---------------#

# This sets up a hatch environment with associated dependencies that need to be installed
[tool.hatch.envs.docs]
description = """Build or serve the documentation."""
# Install optional dependency test for docs
dependency-groups = [
    "docs",
]

# This table contains the scripts that you can use to build and serve your docs
# hatch run docs:build will build your documentation
# hatch run docs:serve will serve them 'live' on your computer locally
[tool.hatch.envs.docs.scripts]
build = ["sphinx-build {args:-W -b html docs docs/_build}"]
serve = ["sphinx-autobuild docs --watch src/aaa {args:-b html docs/_build/serve}"]



#--------------- Check security for your dependencies ---------------#

[tool.hatch.envs.audit]
description = """Check dependencies for security vulnerabilities."""
dependency-groups = [
    "build",
]

[tool.hatch.envs.audit.scripts]
check = ["pip-audit"]
```

</details>

but when we go to actually run the functional tests, hatch doesn't seem to actually be installing any of the dependency group deps, or the package itself... I am pretty positive this has nothing to do with the templating change, when i diff the generated `pyproject.toml` before and after this PR, the only thing that changes pretty much is renaming the table key to `dependency-groups` . I paused the pytest run on errors and went to the generated directory and it also looked fine, and same result - when i tried to run hatch manually it didn't install any of the deps and then errored out.

I have been up and down hatch's documentation and i can't figure out why it doesn't seem to want to install anything! 

the only other thing i can think of is it being related to https://github.com/pypa/hatch/issues/2113 which seems to require that the `builder=true` flag be present for pretty much all the envs.

i lay this PR on the mercy of the court, if anyone can figure this out, gr8

I am opening this up here to see if CI behaves differently and something is just wrong on my machine. idk. 

---

edit: there does seem to be something going wrong where the outer hatch environment that’s running the tests for the template seems to interfere with the inner hatch environment that’s being tested - when i removed the test matrix from the template, another test failed saying that the python 3.10 environment didn’t exist, and it started working again when i removed the matrix from the outer (template) package…

i can also replicate the problems here by removing all the template changes except strictly changing the keys to `dependency-group`, i think something broken in hatch.

(call me old fashioned, but i am sorta liking my old fashioned ways of "simply using venvs" right now, at least with a venv i know exactly where it is and what's in it and there's no tool in between me and python, but all these environment virtualization tools seem to want to get too fancy and break lol)

---

edit2: ope wait no it's just this: https://github.com/pypa/hatch/issues/2152